### PR TITLE
Fixed isJoined field issue and added extra field to Post serializer.

### DIFF
--- a/cmpe451/protopost/serializers.py
+++ b/cmpe451/protopost/serializers.py
@@ -85,7 +85,8 @@ class PostSerializer(serializers.ModelSerializer):
     
     def to_representation(self, instance):
         representation = {
-            "poster_name": instance.poster.username
+            "poster_name": instance.poster.username,
+            "community_name" : instance.community.name
         }
         representation.update(super().to_representation(instance))
         return representation

--- a/cmpe451/protopost/views.py
+++ b/cmpe451/protopost/views.py
@@ -63,6 +63,7 @@ class CreateCommunity(GenericAPIView):
             if community_serializer.is_valid():
                 community=community_serializer.save(moderator=req.user)
                 req.user.joined_communities.add(community)
+                community_serializer=CommunitySerializer(community,context={"request":req})
                 return Response({"Success":True, "Community": community_serializer.data})
             else:
                 return Response({"Success":False, "Error": community_serializer.errors})
@@ -263,6 +264,7 @@ class SearchCommunities(GenericAPIView):
         if req.user.is_authenticated and "text" in req.GET:
             communities = Community.objects.filter(name__icontains = req.GET["text"])
             communities = CommunitySerializer(communities, many=True)
+            communities=CommunitySerializer(communities,many=True,context={"request":req})
             return Response(communities.data)    
         return Response({"Success" : False, "Error": "No authentication  or query parameter not  correctly."})
 


### PR DESCRIPTION
I fixed the bug #198  with the isJoined field returned by SearchCommunities API, it was due a missing context passed onto serializer. I also added "community_name" field to the Post objects which was requested by the Web and Android teams.

This is a quite small PR and a quick look is appreciated.